### PR TITLE
cmd/geth: Add genesis flag

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -320,7 +320,7 @@ func importWallet(ctx *cli.Context) error {
 	if len(keyfile) == 0 {
 		utils.Fatalf("keyfile must be given as argument")
 	}
-	keyJSON, err := ioutil.ReadFile(keyfile)
+	keyJSON, err := os.ReadFile(keyfile)
 	if err != nil {
 		utils.Fatalf("Could not read wallet file: %v", err)
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -58,6 +58,7 @@ var (
 	app = flags.NewApp(gitCommit, gitDate, "the go-ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
+		utils.GenesisFlag,
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -116,7 +116,6 @@ var (
 	GenesisFlag = cli.StringFlag{
 		Name:  "genesis",
 		Usage: "Path to genesis JSON file, ignore genesis block from database",
-		Value: "./genesis.json",
 	}
 	// General settings
 	DataDirFlag = DirectoryFlag{


### PR DESCRIPTION
### Description

add `--genesis` flag, ignore read genesis block from database

### Rationale

`SetEthConfig` adds process for handling Genesis JSON file

### Example

```sh
./geth --datadir=/data/dbsc --genesis=/data/genesis-dbsc-devnet.json
```

### Changes

Notable changes: 
* add `--genesis` flag
