### PR TITLE
core: fix some flaky tests

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1546,18 +1546,20 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 					}
 				}
 				// Garbage collect anything below our required write retention
+				wg2 := sync.WaitGroup{}
 				for !bc.triegc.Empty() {
 					root, number := bc.triegc.Pop()
 					if uint64(-number) > chosen {
 						bc.triegc.Push(root, number)
 						break
 					}
-					wg.Add(1)
+					wg2.Add(1)
 					go func() {
 						triedb.Dereference(root.(common.Hash))
-						wg.Done()
+						wg2.Done()
 					}()
 				}
+				wg2.Wait()
 			}
 		}
 		return nil

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1552,7 +1552,11 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 						bc.triegc.Push(root, number)
 						break
 					}
-					go triedb.Dereference(root.(common.Hash))
+					wg.Add(1)
+					go func() {
+						triedb.Dereference(root.(common.Hash))
+						wg.Done()
+					}()
 				}
 			}
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -251,6 +251,7 @@ func (s *StateDB) StopPrefetcher() {
 	s.prefetcherLock.Lock()
 	if s.prefetcher != nil {
 		s.prefetcher.close()
+		s.prefetcher = nil
 	}
 	s.prefetcherLock.Unlock()
 }

--- a/eth/protocols/diff/handler_test.go
+++ b/eth/protocols/diff/handler_test.go
@@ -134,9 +134,9 @@ func testGetDiffLayers(t *testing.T, protocol uint) {
 	missDiffPackets := make([]FullDiffLayersPacket, 0)
 
 	for i := 0; i < 100; i++ {
-		number := uint64(rand.Int63n(1024))
-		if number == 0 {
-			continue
+		// Find a non 0 random number
+		var number uint64
+		for ; number == 0; number = uint64(rand.Int63n(1024)) {
 		}
 		foundHash := backend.chain.GetCanonicalHash(number + 1024)
 		missHash := backend.chain.GetCanonicalHash(number)

--- a/eth/protocols/diff/handler_test.go
+++ b/eth/protocols/diff/handler_test.go
@@ -17,8 +17,8 @@
 package diff
 
 import (
+	"crypto/rand"
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -134,10 +134,13 @@ func testGetDiffLayers(t *testing.T, protocol uint) {
 	missDiffPackets := make([]FullDiffLayersPacket, 0)
 
 	for i := 0; i < 100; i++ {
-		// Find a non 0 random number
-		var number uint64
-		for ; number == 0; number = uint64(rand.Int63n(1024)) {
+		// Find a non 0 random number (1 ~ 1023)
+		n, err := rand.Int(rand.Reader, big.NewInt(1023))
+		if err != nil {
+			t.Fatalf("Failed to generate random number %v", err)
 		}
+
+		number := n.Uint64() + 1
 		foundHash := backend.chain.GetCanonicalHash(number + 1024)
 		missHash := backend.chain.GetCanonicalHash(number)
 		foundRlp := backend.chain.GetDiffLayerRLP(foundHash)


### PR DESCRIPTION
### Description

Merge upstream fix [1379](https://github.com/bnb-chain/bsc/pull/1379).

The tests panic quite frequently.

### Rationale

The tests no longer panic. I manager to trigger the error (almost) every time with this command:

```
seq 1 10 | parallel go test -count=1 ./eth/downloader -run "TestCanonicalSynchronisation66Full" -v
```
