### PR TITLE
fix: init network

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -502,13 +502,13 @@ func (c *Config) warnOnce(w *bool, format string, args ...interface{}) {
 }
 
 type LogConfig struct {
-	FileRoot     *string
-	FilePath     *string
-	MaxBytesSize *uint
-	Level        *string
+	FileRoot     *string `toml:",omitempty"`
+	FilePath     *string `toml:",omitempty"`
+	MaxBytesSize *uint   `toml:",omitempty"`
+	Level        *string `toml:",omitempty"`
 
 	// TermTimeFormat is the time format used for console logging.
-	TermTimeFormat *string
+	TermTimeFormat *string `toml:",omitempty"`
 	// TimeFormat is the time format used for file logging.
-	TimeFormat *string
+	TimeFormat *string `toml:",omitempty"`
 }


### PR DESCRIPTION
### Description

> upstream PR: [#1412](https://github.com/bnb-chain/bsc/pull/1412)

Description

fields of Node.LogConfig is pointer,
when a field is not set, generate config.toml will fail for marshaling nil

### Changes

Notable changes:

    * add each change in a bullet point here