### PR TITLE
Makefile: fix devtools install error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clean:
 
 devtools:
 	env GOBIN= go install golang.org/x/tools/cmd/stringer@latest
-	env GOBIN= go install github.com/kevinburke/go-bindata/go-bindata@latest
+	env GOBIN= go install github.com/kevinburke/go-bindata@latest
 	env GOBIN= go install github.com/fjl/gencodec@latest
 	env GOBIN= go install github.com/golang/protobuf/protoc-gen-go@latest
 	env GOBIN= go install ./cmd/abigen


### PR DESCRIPTION
### Description

> upstream PR: [#1403](https://github.com/bnb-chain/bsc/pull/1403)

fix dev tools build error. Ref https://github.com/bnb-chain/bsc/issues/1402

May change go-bindata to go embed later;
Changes

### Notable changes:

* Fixed the package path of go-bindata;