### PR TITLE
fix: ibftblock not on dogechain network configs

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -189,6 +189,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		IBFTBlock:           big.NewInt(0),
 		PortlandBlock:       big.NewInt(1981991),
 		DetroitBlock:        big.NewInt(4490834),
 
@@ -208,6 +209,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		IBFTBlock:           big.NewInt(0),
 		PreportlandBlock:    big.NewInt(1062992),
 		PortlandBlock:       big.NewInt(1065956),
 		DetroitBlock:        big.NewInt(2661202),


### PR DESCRIPTION
The default ibft block is not set within genesis configs. So if we use a hard-coded default config instead of a genesis file, we'll fail to load and sync from V1 network.