### PR TITLE
internal/ethapi: EstimateGas should use LatestBlockNumber by default

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1052,8 +1052,8 @@ func (p *Pending) Call(ctx context.Context, args struct {
 func (p *Pending) EstimateGas(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (Long, error) {
-	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	gas, err := ethapi.DoEstimateGas(ctx, p.backend, args.Data, pendingBlockNr, p.backend.RPCGasCap())
+	latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+	gas, err := ethapi.DoEstimateGas(ctx, p.backend, args.Data, latestBlockNr, p.backend.RPCGasCap())
 	return Long(gas), err
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1121,7 +1121,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 // EstimateGas returns an estimate of the amount of gas needed to execute the
 // given transaction against the current pending block.
 func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}


### PR DESCRIPTION
### Description

upstream PR: [go-ethereum#24363](https://github.com/ethereum/go-ethereum/pull/24363)

We met a problem that if the `args TransactionArgs` depends on the latest committed block N, `PendingBlockNumber` is still N-1, which causes the estimation to fail.

`LatestBlockNumber` is a better default value IMO.

https://github.com/ethereum/go-ethereum/pull/24363#issuecomment-1342246263 :

```
if use pendingblocknumber,then in code:
block, err := b.BlockByNumberOrHash(ctx, blockNrOrHash)
you may get error or "block not found".
```
