### PR TITLE
eth/protocols/snap: fix batch writer when resuming an aborted sync

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -736,6 +736,8 @@ func (s *Syncer) loadSyncStatus() {
 			}
 			s.tasks = progress.Tasks
 			for _, task := range s.tasks {
+				task := task // closure for task.genBatch in the stacktrie writer callback
+
 				task.genBatch = ethdb.HookedBatch{
 					Batch: s.db.NewBatch(),
 					OnPut: func(key []byte, value []byte) {
@@ -746,6 +748,8 @@ func (s *Syncer) loadSyncStatus() {
 
 				for _, subtasks := range task.SubTasks {
 					for _, subtask := range subtasks {
+						subtask := subtask // closure for subtask.genBatch in the stacktrie writer callback
+
 						subtask.genBatch = ethdb.HookedBatch{
 							Batch: s.db.NewBatch(),
 							OnPut: func(key []byte, value []byte) {


### PR DESCRIPTION
### Description

upstream PR: [go-ethereum#27842](https://github.com/ethereum/go-ethereum/pull/27842)

Fixes https://github.com/ethereum/go-ethereum/issues/27813.

The closure caused all subtasks to reference the same one batch when writing, so instead of each subtask of a contract growing and flushing it's own batch, they all grew the last one's, but flushed their own.

Interestingly however, this should only be an issue if there's also a lack of peers, otherwise whenever a delivery into the last batch is made, it should have flushed out everyone else's data too.
