### PR TITLE
eth/fetcher: drop peer if block too high

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -410,6 +410,12 @@ func (f *BlockFetcher) loop() {
 			if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
 				log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
 				blockAnnounceDropMeter.Mark(1)
+				// if dist > maxQueueDist and not in announces count, drop peer
+				// forgetHash delete count
+				if count, ok := f.announces[notification.origin]; !ok || count <= 0 {
+					log.Debug("Peer too high, drop it", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
+					f.dropPeer(notification.origin)
+				}
 				break
 			}
 			// All is well, schedule the announce if block's not yet downloading

--- a/les/fetcher/block_fetcher.go
+++ b/les/fetcher/block_fetcher.go
@@ -399,6 +399,12 @@ func (f *BlockFetcher) loop() {
 				if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
 					log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
 					blockAnnounceDropMeter.Mark(1)
+					// if dist > maxQueueDist and not in announces count, drop peer
+					// forgetHash delete count
+					if count, ok := f.announces[notification.origin]; !ok || count <= 0 {
+						log.Debug("Peer too high, drop it", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
+						f.dropPeer(notification.origin)
+					}
 					break
 				}
 			}


### PR DESCRIPTION
### Description

synchronization stop under boundary conditions:
- peer block too high
- local node run in slow disk (Block execute too long)
- local node more than 32 block

`forgetHash` remove peer count, but not drop peer, if notification block too high, never fetch block from the peer

https://github.com/dogechain-lab/dbsc/blob/ce0dbc328051e73abc0a35065741f6c1be531999/eth/fetcher/block_fetcher.go#L933-L946