### PR TITLE
metrics: add txpool config into metrics server

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -178,6 +178,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	utils.SetupMetrics(ctx,
 		utils.EnableBuildInfo(gitCommit, gitDate),
 		utils.EnableMinerInfo(ctx, cfg.Eth.Miner),
+		utils.EnableNodeInfo(cfg.Eth.TxPool),
 	)
 	return stack, backend
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1919,6 +1919,21 @@ func EnableMinerInfo(ctx *cli.Context, minerConfig miner.Config) SetupMetricsOpt
 	}
 }
 
+func EnableNodeInfo(poolConfig core.TxPoolConfig) SetupMetricsOption {
+	return func() {
+		// register node info into metrics
+		metrics.NewRegisteredLabel("node-info", nil).Mark(map[string]interface{}{
+			"PriceLimit":   poolConfig.PriceLimit,
+			"PriceBump":    poolConfig.PriceBump,
+			"AccountSlots": poolConfig.AccountSlots,
+			"GlobalSlots":  poolConfig.GlobalSlots,
+			"AccountQueue": poolConfig.AccountQueue,
+			"GlobalQueue":  poolConfig.GlobalQueue,
+			"Lifetime":     poolConfig.Lifetime,
+		})
+	}
+}
+
 func SetupMetrics(ctx *cli.Context, options ...SetupMetricsOption) {
 	if metrics.Enabled {
 		log.Info("Enabling metrics collection")


### PR DESCRIPTION
### Description

upstream PR https://github.com/bnb-chain/bsc/pull/1788

add TxPool info into metrics server

### Changes

* cmd/utils/flags.go
* cmd/geth/config.go
