### PR TITLE
fix: lagging nodes failed to sync (#1829)

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -318,7 +318,7 @@ func ReadHeaderRange(db ethdb.Reader, number uint64, count uint64) []rlp.RawValu
 		return rlpHeaders
 	}
 	// read remaining from ancients
-	max := count * 700
+	max := count * 700 * 3
 	data, err := db.AncientRange(freezerHeaderTable, i+1-count, count, max)
 	if err == nil && uint64(len(data)) == count {
 		// the data is on the order [h, h+1, .., n] -- reordering needed


### PR DESCRIPTION
### Description

upstream PR https://github.com/bnb-chain/bsc/pull/1829

expanding hard-coded field to avoid risks

### Rationale

FastFinality puts more information into the header.extra field to keep vote information. For mainnet, on epoch height, it could be 1526 bytes, which was 517 bytes before. So the hard-coded 700 bytes for header could be no longer enough, increase it by 2 times would be enough.

this bug could cause P2P sync failure for nodes that are lagging behind, since they would request access of ancient db, and GetBlockHeaders could be failed.

