### PR TITLE
version: upgrade version to latest tag

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	VersionMajor = 1  // Major version component of the current release
-	VersionMinor = 1  // Minor version component of the current release
-	VersionPatch = 21 // Patch version component of the current release
+	VersionMajor = 2  // Major version component of the current release
+	VersionMinor = 0  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

The `geth` binary version is still `1.1.12`, ugprade to the latest tag.