### PR TITLE
eth: default disable diff protocol

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -134,7 +134,7 @@ var (
 	}
 	DisableDiffProtocolFlag = cli.BoolFlag{
 		Name:  "disablediffprotocol",
-		Usage: "Disable diff protocol",
+		Usage: "Disable diff protocol(default is true)",
 	}
 	EnableTrustProtocolFlag = cli.BoolFlag{
 		Name:  "enabletrustprotocol",

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -86,6 +86,7 @@ var Defaults = Config{
 	TriesInMemory:           128,
 	TriesVerifyMode:         core.LocalVerify,
 	SnapshotCache:           102,
+	DisableDiffProtocol:     true,
 	DiffBlock:               uint64(86400),
 	Miner: miner.Config{
 		GasCeil:       8000000,


### PR DESCRIPTION
### Description

disable `diff` protocol by default, `diff` protocol is deprecated,will be deleted in the future

https://github.com/bnb-chain/bsc/issues/1485
https://github.com/bnb-chain/bsc/pull/1486
