### PR TITLE
consensus/drab: disable self reorg preserving

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -467,6 +467,9 @@ func (s *Ethereum) shouldPreserve(header *types.Header) bool {
 	if _, ok := s.engine.(*parlia.Parlia); ok {
 		return false
 	}
+	if _, ok := s.engine.(*drab.Drab); ok {
+		return false
+	}
 	return s.isLocalBlock(header)
 }
 


### PR DESCRIPTION
### Description

The reason we need to disable the self-reorg preserving for `drab` is it can be probable to introduce a deadlock.
It was disabled in `clique` and `parlia` consensus for the same reason.