### PR TITLE
fix: revert hawaii fork to london instruction set

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -55,7 +55,7 @@ var (
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
-	hawaiiInstructionSet           = newMergeInstructionSet()
+	hawaiiInstructionSet           = newLondonInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.


### PR DESCRIPTION
### Description

Panic due to not support instruction of merge fork.