### PR TITLE
fix: snap synchronization failed

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -406,12 +406,6 @@ func (f *BlockFetcher) loop() {
 			if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
 				log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
 				blockAnnounceDropMeter.Mark(1)
-				// if dist > maxQueueDist and not in announces count, drop peer
-				// forgetHash delete count
-				if count, ok := f.announces[notification.origin]; !ok || count <= 0 {
-					log.Debug("Peer too high, drop it", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
-					f.dropPeer(notification.origin)
-				}
 				break
 			}
 			// All is well, schedule the announce if block's not yet downloading

--- a/les/fetcher/block_fetcher.go
+++ b/les/fetcher/block_fetcher.go
@@ -395,19 +395,14 @@ func (f *BlockFetcher) loop() {
 				blockAnnounceDOSMeter.Mark(1)
 				break
 			}
+			if notification.number == 0 {
+				break
+			}
 			// If we have a valid block number, check that it's potentially useful
-			if notification.number > 0 {
-				if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
-					log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
-					blockAnnounceDropMeter.Mark(1)
-					// if dist > maxQueueDist and not in announces count, drop peer
-					// forgetHash delete count
-					if count, ok := f.announces[notification.origin]; !ok || count <= 0 {
-						log.Debug("Peer too high, drop it", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
-						f.dropPeer(notification.origin)
-					}
-					break
-				}
+			if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
+				log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
+				blockAnnounceDropMeter.Mark(1)
+				break
 			}
 			// All is well, schedule the announce if block's not yet downloading
 			if _, ok := f.fetching[notification.hash]; ok {

--- a/les/fetcher/block_fetcher.go
+++ b/les/fetcher/block_fetcher.go
@@ -395,14 +395,13 @@ func (f *BlockFetcher) loop() {
 				blockAnnounceDOSMeter.Mark(1)
 				break
 			}
-			if notification.number == 0 {
-				break
-			}
 			// If we have a valid block number, check that it's potentially useful
-			if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
-				log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
-				blockAnnounceDropMeter.Mark(1)
-				break
+			if notification.number > 0 {
+				if dist := int64(notification.number) - int64(f.chainHeight()); dist < -maxUncleDist || dist > maxQueueDist {
+					log.Debug("Peer discarded announcement", "peer", notification.origin, "number", notification.number, "hash", notification.hash, "distance", dist)
+					blockAnnounceDropMeter.Mark(1)
+					break
+				}
 			}
 			// All is well, schedule the announce if block's not yet downloading
 			if _, ok := f.fetching[notification.hash]; ok {


### PR DESCRIPTION
### Description

Fix: #56 

PR #31 misunderstood the synchronization logic. In the state of snapshot synchronization, the height of the peer block should be much higher than the local, the node should not be disconnected.